### PR TITLE
Explicitly require barcode type (barby no longer does this by default)

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,24 +1,47 @@
 = has_barcode
 
-A nice wrapper for Barcode generation using barby
+A nice wrapper for Barcode generation using {barby}[https://github.com/toretore/barby].
 
-  class SomethingImportant
-    has_barcode :barcode, 
-      :outputter => :png, 
+  class Product
+    include HasBarcode
+
+    has_barcode :barcode,
+      :outputter => :png,
       :type => :code_39,
-      :value => Proc.new{|p| p.number}
+      :value => Proc.new { |p| p.number }
 
     def number
       self.id
     end
   end
 
-  SomethingImportant.new.barcode => Barby::Code39 object
-  SomethingImportant.new.barcode_data => <Barby::Code39 object>.to_png
+  Product.new.barcode       # => Barby::Code39 object
+  Product.new.barcode_data  # => <Barby::Code39 object>.to_png
+
+== Why <tt>has_barcode</tt> is a good choice for Heroku
+Other libraries – such as {barcode_generator}[https://github.com/anujluthra/barcode-generator] – commonly rely on {gbarcode}[https://github.com/ahx/gbarcode], a GNU Barcode C library. This is problem since you need to install GNU barcode which {Heroku does not support}[https://github.com/perezd/barcoder/issues/1]. <tt>has_barcode</tt> doesn't have this dependency.
+
+A typical Heroku setup might look like:
+
+  class Coupon < ActiveRecord::Base
+    include HasBarcode
+
+    has_barcode :barcode,
+      :outputter => :svg,
+      :type => :code_39,
+      :value => Proc.new { |c| c.id }
+
+  end
+
+Notice we're using the <tt>svg</tt> outputter. This is good choice since it doesn't need to store images in the file system, which can be an issue given {Heroku's read only file system}[http://devcenter.heroku.com/articles/read-only-filesystem].
+
+To display your barcode in the view, do something like:
+
+  @coupon.barcode_data.html_safe
 
 
 == Note on Patches/Pull Requests
- 
+
 * Fork the project.
 * Make your feature addition or bug fix.
 * Add tests for it. This is important so I don't break it in a

--- a/README.rdoc
+++ b/README.rdoc
@@ -18,8 +18,8 @@ A nice wrapper for Barcode generation using {barby}[https://github.com/toretore/
   Product.new.barcode       # => Barby::Code39 object
   Product.new.barcode_data  # => <Barby::Code39 object>.to_png
 
-== Why <tt>has_barcode</tt> is a good choice for Heroku
-Other libraries – such as {barcode_generator}[https://github.com/anujluthra/barcode-generator] – commonly rely on {gbarcode}[https://github.com/ahx/gbarcode], a GNU Barcode C library. This is problem since you need to install GNU barcode which {Heroku does not support}[https://github.com/perezd/barcoder/issues/1]. <tt>has_barcode</tt> doesn't have this dependency.
+== Why has_barcode is a good choice for Heroku
+Other libraries – such as {barcode_generator}[https://github.com/anujluthra/barcode-generator] – commonly rely on {gbarcode}[https://github.com/ahx/gbarcode], a GNU Barcode C library. This is problem since you need to install GNU barcode which {Heroku does not support}[https://github.com/perezd/barcoder/issues/1]. Luckily <tt>has_barcode</tt> doesn't have this dependency.
 
 A typical Heroku setup might look like:
 

--- a/lib/has_barcode.rb
+++ b/lib/has_barcode.rb
@@ -16,7 +16,11 @@ module HasBarcode
       @@barcode_configurations[args.first] = HasBarcode::Configuration.new(options)
 
       define_method args.first do
-        @@barcode_configurations[args.first].barcode_class.new(options[:value].call(self))      
+        if options[:type] == :code_128
+          @@barcode_configurations[args.first].barcode_class.new(options[:value].call(self), 'A')
+        else
+          @@barcode_configurations[args.first].barcode_class.new(options[:value].call(self))
+        end
       end
 
       define_method "#{args.first}_data" do

--- a/lib/has_barcode/configuration.rb
+++ b/lib/has_barcode/configuration.rb
@@ -6,12 +6,14 @@ module HasBarcode
       opts.symbolize_keys!
 
       @name = args.first
+
+      require "barby/barcode/#{opts[:type]}"
       @barcode_class = Barby.const_get("#{opts[:type].to_s.classify}")
 
       require "barby/outputter/#{opts[:outputter]}_outputter"
       @outputter = Barby.const_get("#{opts[:outputter]}_outputter".classify)
     end
 
-    
+
   end
 end


### PR DESCRIPTION
Barby no longer requires the various symbology types by default, meaning that we need to explicitly require the `type` as part of the configuration. Following your lead, I've required the `type` in the same fashion that you've required the `outputter`. Pretty straight forward.

Also, I updated the read me to explain why this is a good gem to use with heroku. I actually tried a few options before arriving at `has_barcode`. I think this little addition would be helpful.

Thanks for building this!
Cory
