### PR TITLE
specifically setting the class name

### DIFF
--- a/lib/has_barcode/configuration.rb
+++ b/lib/has_barcode/configuration.rb
@@ -1,13 +1,14 @@
 module HasBarcode
   class Configuration
-    attr_reader :name, :barcode_class, :outputter_class
+    attr_reader :name, :barcode_class, :outputter
     def initialize(*args)
       opts = ActiveSupport::HashWithIndifferentAccess.new(args.last.kind_of?(Hash) ? (args.last || {}) : {})
 
       @name = args.first
 
       require "barby/barcode/#{opts[:type]}"
-      @barcode_class = Barby.const_get(ActiveSupport::Inflector.classify("#{opts[:type].to_s}"))
+      class_name = (opts[:barcode_class_name] || opts[:type]).to_s
+      @barcode_class = Barby.const_get(ActiveSupport::Inflector.classify(class_name))
 
       require "barby/outputter/#{opts[:outputter]}_outputter"
       @outputter = Barby.const_get(ActiveSupport::Inflector.classify("#{opts[:outputter]}_outputter"))

--- a/spec/has_barcode/configuration_spec.rb
+++ b/spec/has_barcode/configuration_spec.rb
@@ -18,7 +18,26 @@ describe "a barcode configuration" do
   end
 
   it "should have an outputter" do
+    @configuration.outputter.should eql(Barby::PngOutputter)
+  end
+end
+describe "a barcode configuration with class set" do
+  before(:each) do
+    @configuration = HasBarcode::Configuration.new(:barcode, :outputter => :png, :type => :ean_13, :barcode_class_name => "EAN13")
+  end
 
-  end 
+  it "should have a name" do
+    @configuration.name.should_not be_nil
+    @configuration.name.should eql(:barcode)
+  end
+
+  it "should have a barcode class" do
+    @configuration.barcode_class.should eql(Barby::EAN13)
+  end
+
+  it "should have an outputter" do
+    @configuration.outputter.should eql(Barby::PngOutputter)
+  end
+
 end
 


### PR DESCRIPTION
Since the class EAN13 is in capitals, I needed to set the classname manually. This can now be done like this:

``` ruby
  has_barcode( :barcode,
               :type => :ean_13,
               :outputter => :png,
               :value => Proc.new { |c| c.padded_number },
               :barcode_class_name => "EAN13")
```

When "barcode_class_name" isn't given the fallback "type" is used like before
