### PR TITLE
Allow for type class override, and provide access to the config from the receiving model.

### DIFF
--- a/lib/has_barcode.rb
+++ b/lib/has_barcode.rb
@@ -34,6 +34,11 @@ module HasBarcode
         end
       end
 
+      define_method "#{args.first}_config" do
+        @@barcode_configurations[args.first]
+      end
+
+
     end
 
     def barcode_configurations

--- a/lib/has_barcode/configuration.rb
+++ b/lib/has_barcode/configuration.rb
@@ -7,7 +7,7 @@ module HasBarcode
       @name = args.first
 
       require "barby/barcode/#{opts[:type]}"
-      @barcode_class = Barby.const_get(ActiveSupport::Inflector.classify("#{opts[:type].to_s}"))
+      @barcode_class = opts[:type_class] || Barby.const_get(ActiveSupport::Inflector.classify("#{opts[:type].to_s}"))
 
       require "barby/outputter/#{opts[:outputter]}_outputter"
       @outputter = Barby.const_get(ActiveSupport::Inflector.classify("#{opts[:outputter]}_outputter"))


### PR DESCRIPTION
Certain types will not load with has_barcode, such as :ean_13 which looks for Bardy::Ean13 instead of the correct Bardy::EAN13. With this pull request, you can pass has_barcode the :type_class with the full class and it will work correctly.

Additionally, I have exposed the config so that the original type or other options are available from the model (in case you want to validate your barcode and output the type in the validation error).
